### PR TITLE
issue #4 display_errors update

### DIFF
--- a/control/config.php
+++ b/control/config.php
@@ -13,7 +13,7 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU Affero General Public License along with this program.  If not, see http://www.gnu.org/licenses/agpl-3.0.html
 */
 
-ini_set('display_errors', 0);
+ini_set('display_errors', 1);
 
 $dsn = 'mysql:host=localhost;dbname='; // SQL database name
 $user = ""; // SQL username
@@ -33,12 +33,12 @@ $site_name=''; // Site name
 $admin_home=''; // Directory
 $this_domain=$_SERVER['HTTP_HOST'];
 $salt=''; // salt for md5 hash
-$debug='no';
+$debug='yes';
 
-$site_vars[site_email]=''; // Site email
-$site_vars[site_name]='';  // Site name
-$site_vars[admin_home]='';  // Directory
-$site_vars[this_domain]=$_SERVER['HTTP_HOST'];
-$site_vars[salt]='';  // salt for md5 hash
-$site_vars[debug]='no';
+$site_vars['site_email']=''; // Site email
+$site_vars['site_name']='';  // Site name
+$site_vars['admin_home']='';  // Directory
+$site_vars['this_domain']=$_SERVER['HTTP_HOST'];
+$site_vars['salt']='';  // salt for md5 hash
+$site_vars['debug']='yes';
 ?>

--- a/control/file.php
+++ b/control/file.php
@@ -114,8 +114,6 @@ function Image($image, $crop = null, $size = null) {
         return false;
     }
 
-    ini_set('display_errors', 1);
-
     $id=$_GET['id'];
     $table=$_GET['table'];
     $field=$_GET['field'];

--- a/control/functions.php
+++ b/control/functions.php
@@ -13,8 +13,6 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU Affero General Public License along with this program.  If not, see http://www.gnu.org/licenses/agpl-3.0.html
 */
 
-ini_set('display_errors', 1);
-
 // get the template and content file
 function new_sign_ups() {
     global $page_control;

--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU Affero General Public License along with this program.  If not, see http://www.gnu.org/licenses/agpl-3.0.html
 */
 session_start();
-ini_set('display_errors', 1);
+
 //load config
 include ("control/config.php");
 

--- a/js/ajax.php
+++ b/js/ajax.php
@@ -14,7 +14,6 @@ You should have received a copy of the GNU Affero General Public License along w
 */
 
 include ("../control/config.php");
-ini_set('display_errors', 1);
 
 function toAscii($str) {
     $clean = preg_replace("/[^a-zA-Z0-9\/_|+ -]/", '', $str);

--- a/mailfunctions/debian2.php
+++ b/mailfunctions/debian2.php
@@ -13,7 +13,6 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU Affero General Public License along with this program.  If not, see http://www.gnu.org/licenses/agpl-3.0.html
 */
 
-ini_set('display_errors', 1);
 include ("../control/config.php");
 require_once('../control/class.phpmailer.php');
 

--- a/mailfunctions/test.php
+++ b/mailfunctions/test.php
@@ -19,8 +19,6 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU Affero General Public License along with this program.  If not, see http://www.gnu.org/licenses/agpl-3.0.html
 */
 
-ini_set('display_errors', 1);
-
 function getmsg($mbox,$mid) {
     // input $mbox = IMAP stream, $mid = message id
     // output all the following:

--- a/templates/admin_templates/angular.php
+++ b/templates/admin_templates/angular.php
@@ -13,8 +13,6 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU Affero General Public License along with this program.  If not, see http://www.gnu.org/licenses/agpl-3.0.html
 */
 
-ini_set('display_errors', 1);
-
 if (isset($_GET['delete_user'])) {
     delete_user($_GET['delete_user']);
 }

--- a/templates/public_templates/create.php
+++ b/templates/public_templates/create.php
@@ -13,8 +13,6 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU Affero General Public License along with this program.  If not, see http://www.gnu.org/licenses/agpl-3.0.html
 */
 
-ini_set('display_errors', 1);
-
 echo '<pre>';
 print_r($_POST);
 print_r($_GET);


### PR DESCRIPTION
remove display_error lines from various files as mentioned in issue #4 

This leaves the only setting for display_errors in the `control/config.php` file which is good.

Also, for now, `display_errors` and `debug` are switched ON which I think is a sensible default setting at the moment while we are getting `ecosystem` back on its feet - it will be disabled again later.
